### PR TITLE
remove [ExecuteInEditMode]

### DIFF
--- a/UiRoundedCorners/ImageWithIndependentRoundedCorners.cs
+++ b/UiRoundedCorners/ImageWithIndependentRoundedCorners.cs
@@ -2,7 +2,6 @@
 using UnityEngine.UI;
 
 namespace Nobi.UiRoundedCorners {
-	[ExecuteInEditMode]
 	[RequireComponent(typeof(RectTransform))]
 	public class ImageWithIndependentRoundedCorners : MonoBehaviour {
 		private static readonly int prop_halfSize = Shader.PropertyToID("_halfSize");

--- a/UiRoundedCorners/ImageWithRoundedCorners.cs
+++ b/UiRoundedCorners/ImageWithRoundedCorners.cs
@@ -2,7 +2,6 @@
 using UnityEngine.UI;
 
 namespace Nobi.UiRoundedCorners {
-	[ExecuteInEditMode]
 	[RequireComponent(typeof(RectTransform))]
 	public class ImageWithRoundedCorners : MonoBehaviour {
 		private static readonly int Props = Shader.PropertyToID("_WidthHeightRadius");


### PR DESCRIPTION
Using an `ImageWithRoundedCorners` component inside a prefab on Unity 2021.3+ causes a popup warning about [ExecuteInEditMode] to appear when entering playmode.
![image](https://user-images.githubusercontent.com/1483568/215894888-62b4a5dd-7bbc-48f1-b1e5-f2d56362869f.png)

[Unity Documentation](https://docs.unity3d.com/ScriptReference/ExecuteInEditMode.html) mentions switching to [ExecuteAlways]. However, from what I can tell, [ExecuteInEditMode] can be safely removed without adding [ExecuteAlways] due to the already existing usage of `OnValidate`.