### PR TITLE
Adds support for a mask itself to have 'rounded corners'.

### DIFF
--- a/UiRoundedCorners/IndependentRoundedCorners.shader
+++ b/UiRoundedCorners/IndependentRoundedCorners.shader
@@ -78,6 +78,11 @@
                 }
 
                 float alpha = CalcAlphaForIndependentCorners(i.uv, _halfSize.xy, _rect2props, _r);
+
+                #ifdef UNITY_UI_ALPHACLIP
+                clip(alpha - 0.001);
+                #endif
+                
                 return mixAlpha(tex2D(_MainTex, i.uv), i.color, alpha);
             }
             

--- a/UiRoundedCorners/RoundedCorners.shader
+++ b/UiRoundedCorners/RoundedCorners.shader
@@ -74,6 +74,11 @@ Shader "UI/RoundedCorners/RoundedCorners" {
                 }
 
                 float alpha = CalcAlpha(i.uv, _WidthHeightRadius.xy, _WidthHeightRadius.z);
+
+                #ifdef UNITY_UI_ALPHACLIP
+                clip(alpha - 0.001);
+                #endif
+                
                 return mixAlpha(tex2D(_MainTex, i.uv), i.color, alpha);
             }
             


### PR DESCRIPTION
Adds the functionality that was requested in issue #6.  

Tested on macOS & appears to work fine.  There's some weirdness around when it updates (due to `image.materialForRendering` vs `image.material` -- but that's an existing/Unity-side issue that's only tangentially related; nothing here makes it worse or changes that aspect in any way).

FWIW, based on my understanding of how Unity's masking works via the Stencil buffer, I _did_ expect the change would work prior to trying/testing it.  It works as I'd expect.  :)

Tyvm for this lib btw -- it's been helpful!