### PR TITLE
Quality of Life Update

### DIFF
--- a/UiRoundedCorners/ImageWithRoundedCorners.cs
+++ b/UiRoundedCorners/ImageWithRoundedCorners.cs
@@ -2,12 +2,14 @@
 using UnityEngine.UI;
 
 namespace Nobi.UiRoundedCorners {
-	[RequireComponent(typeof(RectTransform))]
+    [ExecuteInEditMode]								//Required to check the OnEnable function
+    [DisallowMultipleComponent]                     //You can only have one of these in every object.
+    [RequireComponent(typeof(RectTransform))]
 	public class ImageWithRoundedCorners : MonoBehaviour {
 		private static readonly int Props = Shader.PropertyToID("_WidthHeightRadius");
 
-		public float radius;
-		private Material material;
+        public float radius = 40f;          
+        private Material material;
 
 		[HideInInspector, SerializeField] private MaskableGraphic image;
 
@@ -17,13 +19,24 @@ namespace Nobi.UiRoundedCorners {
 		}
 
 		private void OnDestroy() {
-			DestroyHelper.Destroy(material);
+            image.material = null;      //This makes so that when the component is removed, the UI material returns to null
+
+            DestroyHelper.Destroy(material);
 			image = null;
 			material = null;
 		}
 
 		private void OnEnable() {
-			Validate();
+            //You can only add either ImageWithRoundedCorners or ImageWithIndependentRoundedCorners
+            //It will replace the other component when added into the object.
+            var other = GetComponent<ImageWithIndependentRoundedCorners>();
+            if (other != null)
+            {
+                radius = other.r.x;					//When it does, transfer the radius value to this script
+                DestroyHelper.Destroy(other);
+            }
+
+            Validate();
 			Refresh();
 		}
 
@@ -49,7 +62,10 @@ namespace Nobi.UiRoundedCorners {
 
 		public void Refresh() {
 			var rect = ((RectTransform)transform).rect;
-			material.SetVector(Props, new Vector4(rect.width, rect.height, radius, 0));
-		}
+
+            //Multiply radius value by 2 to make the radius value appear consistent with ImageWithIndependentRoundedCorners script.
+            //Right now, the ImageWithIndependentRoundedCorners appears to have double the radius than this.
+            material.SetVector(Props, new Vector4(rect.width, rect.height, radius * 2, 0));   
+        }
 	}
 }


### PR DESCRIPTION
I added some quality of life update in this commit. Mostly to make it easier to use for new user without needing to look at the code. 

1. Added a custom Editor script in ImageWithIndependentRoundedCorners to display Vector4 in separate labels for the four corners in the ImageWithIndependentRoundedCorners. This makes it very clear which corner is which. Previously it was just a Vector4 with w, x, y, z. Now it's Top Left, Top Right, Bottom Right, Bottom Left.

2. Added a line in OnDestroy() to set the UI Image material to null after the component is removed. Previously, when you delete this component, the UI Image material goes to "Missing". Now it's properly reset to null.

3. Added a validation in OnEnable(). Now you can either has ImageWithIndependentRoundedCorners or ImageWithRoundedCorners. You can't have both in the same object. I also added [ExecuteInEditMode] so this validation will run properly.

4. Added [DisallowMultipleComponent] to both scripts. Only one of these components can exist in every gameobject, since only one of them can influence the shader anyway.

5. Added a default value for the radius when the component is added. This gives the user instant feedback that the script works without needing to alter the value first.

6. Make the radius value consistent between two components. When ImageWIthRoundedCorners and ImageWithIndependentRoundedCorners have the same radius value, the ImageWithIndependentRoundedCorners appear to have bigger radius. To compensate this, I multiply the radius by two in ImageWithRoundedCorners as a quick fix. Maybe you can figure it the root cause further.

7. If the user swapped the ImageWithRoundedCorners with ImageWithIndependentCorners, the radius value will be carried over. The other way also works using the radius Vector4.x value.

<img src="https://i.imgur.com/M54vlGi.jpeg" width=100% height=100%>