### PR TITLE
Fix intermittent OnDestroy error

### DIFF
--- a/UiRoundedCorners/ImageWithIndependentRoundedCorners.cs
+++ b/UiRoundedCorners/ImageWithIndependentRoundedCorners.cs
@@ -51,7 +51,9 @@ namespace Nobi.UiRoundedCorners {
 		}
 
 		private void OnDestroy() {
-            image.material = null;      //This makes so that when the component is removed, the UI material returns to null
+			if (image != null) {
+				image.material = null;      //This makes so that when the component is removed, the UI material returns to null
+			}
 
             DestroyHelper.Destroy(material);
 			image = null;

--- a/UiRoundedCorners/ImageWithRoundedCorners.cs
+++ b/UiRoundedCorners/ImageWithRoundedCorners.cs
@@ -19,7 +19,9 @@ namespace Nobi.UiRoundedCorners {
 		}
 
 		private void OnDestroy() {
-            image.material = null;      //This makes so that when the component is removed, the UI material returns to null
+			if (image != null) {
+				image.material = null;      //This makes so that when the component is removed, the UI material returns to null
+			}
 
             DestroyHelper.Destroy(material);
 			image = null;


### PR DESCRIPTION
An intermittent error will be thrown when stopping the Unity editor during the use of the ImageWithRoundedCorners interface.

> NullReferenceException: Object reference not set to an instance of an object
Nobi.UiRoundedCorners.ImageWithRoundedCorners.OnDestroy () (at Assets/Plugins/UiRoundedCorners/ImageWithRoundedCorners.cs:22)

In fact, this issue can be easily fixed by adding a null check during execution.