### PR TITLE
Added Multi Object Editing Support

### DIFF
--- a/UiRoundedCorners/Editor/ImageWithIndependentRoundedCornersInspector.cs
+++ b/UiRoundedCorners/Editor/ImageWithIndependentRoundedCornersInspector.cs
@@ -2,7 +2,7 @@ using UnityEditor;
 using UnityEngine.UI;
 
 namespace Nobi.UiRoundedCorners.Editor {
-    [CustomEditor(typeof(ImageWithIndependentRoundedCorners))]
+    [CustomEditor(typeof(ImageWithIndependentRoundedCorners)), CanEditMultipleObjects]
     public class ImageWithIndependentRoundedCornersInspector : UnityEditor.Editor {
         private ImageWithIndependentRoundedCorners script;
 

--- a/UiRoundedCorners/Editor/ImageWithRoundedCornersInspector.cs
+++ b/UiRoundedCorners/Editor/ImageWithRoundedCornersInspector.cs
@@ -2,7 +2,7 @@ using UnityEditor;
 using UnityEngine.UI;
 
 namespace Nobi.UiRoundedCorners.Editor {
-    [CustomEditor(typeof(ImageWithRoundedCorners))]
+    [CustomEditor(typeof(ImageWithRoundedCorners)), CanEditMultipleObjectsCanEditMultipleObjects]
     public class ImageWithRoundedCornersInspector : UnityEditor.Editor {
         private ImageWithRoundedCorners script;
 


### PR DESCRIPTION
With this small change you are able to modify the radius properties when selecting multiple objects at once.

Before you would get this annoying warning:
![image](https://github.com/user-attachments/assets/9096027c-b11a-48ef-a8c9-7119fbc309f4)

Example:
![exmaple](https://github.com/user-attachments/assets/e9ab79b4-eef0-461c-8a26-5fc7d4fe4e1c)


See [this page](https://docs.unity3d.com/ScriptReference/CanEditMultipleObjects.html) for details.