### PR TITLE
Fix error in latest commit

### DIFF
--- a/UiRoundedCorners/Editor/ImageWithRoundedCornersInspector.cs
+++ b/UiRoundedCorners/Editor/ImageWithRoundedCornersInspector.cs
@@ -2,7 +2,7 @@ using UnityEditor;
 using UnityEngine.UI;
 
 namespace Nobi.UiRoundedCorners.Editor {
-    [CustomEditor(typeof(ImageWithRoundedCorners)), CanEditMultipleObjectsCanEditMultipleObjects]
+    [CustomEditor(typeof(ImageWithRoundedCorners)), CanEditMultipleObjects]
     public class ImageWithRoundedCornersInspector : UnityEditor.Editor {
         private ImageWithRoundedCorners script;
 


### PR DESCRIPTION
The last commit had the following error when compiled into Unity: ImageWithRoundedCornersInspector extends `CanEditMultipleObjectsCanEditMultipleObjects` instead of `CanEditMultipleObjects`. This pull request fixes it.